### PR TITLE
Fixed Ncurses screen drawing for -v and -c modes.

### DIFF
--- a/vtclock.c
+++ b/vtclock.c
@@ -157,6 +157,7 @@ void
 vtclock_print_string(WINDOW *win, int y, int x,
                      char *str)
 {
+  wclear(win); /* Fixes -v and -c mode screen over-writing */
   if (vtclock_inverse) 
     {
       char *p;
@@ -187,6 +188,7 @@ void
 vtclock_print_blank_version_of_string(WINDOW *win, int y, int x, char *str)
 {
   char *p;
+  wclear(win); /* Fixes screen over-writing in -v and -c modes */
   mvwin(win, y, x);
   for (p = str; *p; ++p) {
     if (iscntrl(*p)) {
@@ -474,6 +476,7 @@ main(int argc, char **argv) {
 
     if (blinking_colons) {
       mydelay_half();
+      mvwin(cl, y, x); /* Position the blank colon */
       DRAW_BLANK_COLON(c1, colon1);
       DRAW_BLANK_COLON(c2, colon2);
       wnoutrefresh(cl);


### PR DESCRIPTION
None of the Ncurses screen-drawing stuff was working for me when calling with -v or -c. Clock appeared on screen but never updated but appeared that something was going on underneath. DIscovered that it needed to call wclear() before drawing the windows.

Blinking cursor never worked for the same reason then when I fixed the above it was wrongly positioned. Added the appropriate mvwin() to resolve this.

Been using this on a FreeBSD 4.x system since 2006 for an office clock. Must check the source on that box as it appears to work OK.