### PR TITLE
fix implicit declaration of isspace

### DIFF
--- a/figlet.c
+++ b/figlet.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <stdio.h>
+#include <ctype.h>
 
 #include "vtclock.h"
 #include "font.h"


### PR DESCRIPTION
Currently make issues the following compiler warning because of a missing include:

```
$ make
Fixing dependencies for figlet.c . . .
Fixing dependencies for msg.c . . .
Fixing dependencies for vtclock.c . . .
cc -c     vtclock.c
cc -c     msg.c
cc -c     figlet.c
figlet.c: In function ‘get_character_dimensions’:
figlet.c:78:14: warning: implicit declaration of function ‘isspace’ [-Wimplicit-function-declaration]
   } else if (isspace(*p)) {
              ^~~~~~~
cc  -o vtclock vtclock.o msg.o figlet.o  -lncurses 
```